### PR TITLE
Practice/section3

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,13 +1,7 @@
 package main
 
-import (
-	"fmt"
-
-	"Go_language_practice/section3"
-)
+import "Go_language_practice/section3"
 
 func main() {
-	r := section3.Pointer()
-
-	fmt.Println(r)
+	section3.New()
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,19 @@
 package main
 
-import "Go_language_practice/section3"
+import (
+	"fmt"
+
+	"Go_language_practice/section3"
+)
 
 func main() {
-	section3.New()
+	v := section3.Vertex{1, 2, "test"}
+
+	fmt.Println("関数実行前", v)
+	section3.ChangeVertex(v)
+	fmt.Println("関数実行後", v)
+
+	v2 := &section3.Vertex{1, 2, "test"}
+	section3.ChangeVertex2(v2)
+	fmt.Println(v2)
 }

--- a/main.go
+++ b/main.go
@@ -1,4 +1,13 @@
 package main
 
+import (
+	"fmt"
+
+	"Go_language_practice/section3"
+)
+
 func main() {
+	r := section3.Pointer()
+
+	fmt.Println(r)
 }

--- a/section3/new.go
+++ b/section3/new.go
@@ -1,0 +1,14 @@
+package section3
+
+import "fmt"
+
+func New() {
+	s := make([]int, 0)
+	fmt.Printf("%T\n", s)
+
+	var p *int = new(int)
+	fmt.Printf("%T\n", p)
+
+	//var p2 *int
+	//fmt.Println(p2)
+}

--- a/section3/pointer.go
+++ b/section3/pointer.go
@@ -1,0 +1,15 @@
+package section3
+
+func one(x int) {
+	x = 1
+}
+
+func Pointer() int {
+	var n int = 100
+
+	one(n)
+	result := n
+	//result2 := &n
+
+	return result
+}

--- a/section3/struct.go
+++ b/section3/struct.go
@@ -1,0 +1,17 @@
+package section3
+
+// Vertex Q: 構造体の命名をpublicにしてフィールド名をprivateにしたらどうなるのか？
+// A: 外部からフィールドにアクセスできない
+// Q: この使い方は実装的にあり得るのか？
+type Vertex struct {
+	X, Y int
+	S    string
+}
+
+func ChangeVertex(v Vertex) {
+	v.X = 1000
+}
+
+func ChangeVertex2(v *Vertex) {
+	v.X = 1000
+}


### PR DESCRIPTION


- ポインターについて学習
　- アドレスの概念を学んだメモリの領域を一つにして値を書き換えたりすることができたりする

- 構造体(struct)について学習
　- Goの仕様的に先頭文字を大文字か小文字にするかによってpublicかprivateかを使い分ける
　- 実装では構造体を使用してオブジェクト指向的な思想に基づいて開発をしたりする

- その他
- main.goをエントリーポイントとして各パッケージを実行する
- jsとかみたいに値渡しか参照渡しかは実装者側でポインターの使用の有無で選択ができる
　- Goの値渡し、参照渡しかの概念は再度調査が必要。